### PR TITLE
Feature/change cwd before dap run

### DIFF
--- a/lua/nvim-dap-profiles/api.lua
+++ b/lua/nvim-dap-profiles/api.lua
@@ -9,9 +9,9 @@ local M = {}
 function M.prompt_create_profile()
 end
 
-function M.create_profile(path, name)
+function M.create_profile(name, binary_path, run_dir_path)
     async.run(function()
-        if path == nil or path == "" then
+        if binary_path == nil or binary_path == "" then
             print("Path is nil or empty")
             return
         end
@@ -21,34 +21,42 @@ function M.create_profile(path, name)
             return
         end
 
-        if misc.xpcallargs(profiles.create_profile, path, name) then
+        if misc.xpcallargs(profiles.create_profile, name, binary_path, run_dir_path) then
             serializer.serialize_profiles()
         end
     end)
 end
 
-function M.switch_to_profile(profile_name)
+function M.switch_to_profile(name)
     async.run(function()
-        if misc.is_profile_name_invalid(profile_name) then
+        if misc.is_profile_name_invalid(name) then
             return
         end
 
-        if misc.xpcallargs(profiles.set_active_profile, profile_name) then
+        if misc.xpcallargs(profiles.set_active_profile, name) then
             serializer.serialize_profiles()
         end
     end)
 end
 
-function M.delete_profile(profile_name)
+function M.delete_profile(name)
     async.run(function()
-        if misc.is_profile_name_invalid(profile_name) then
+        if misc.is_profile_name_invalid(name) then
             return
         end
 
-        if misc.xpcallargs(profiles.delete_profile, profile_name) then
+        if misc.xpcallargs(profiles.delete_profile, name) then
             serializer.serialize_profiles()
         end
     end)
+end
+
+function M.add_pre_run_callback(callback)
+    misc.xpcallargs(app.add_pre_run_callback, callback)
+end
+
+function M.add_post_run_callback(callback)
+
 end
 
 return M

--- a/lua/nvim-dap-profiles/app.lua
+++ b/lua/nvim-dap-profiles/app.lua
@@ -1,34 +1,102 @@
 local serializer = require("nvim-dap-profiles.profiles_serializer")
 local profiles = require("nvim-dap-profiles.profiles")
+local event_dispatcher = require("nvim-dap-profiles.event_dispatcher")
+local events = require("nvim-dap-profiles.events")
 local dap = require("dap")
 
 local M = {}
 
-local function intercept_run_fn_and_insert_program()
+local function profiles_run()
     local original_run = dap.run
     dap.run = function(config, opts)
+        -- Make sure to always deserialize profiles before running, otherwise, we risk not using
+        -- the latest profiles if the user updated the file directly.
+        -- This should not be an issue as long as the profiles are serialized after any changes.
+        -- Otherwise, we would risk running with outdated profiles.
+        serializer.deserialize_profiles()
+
+        local profile = nil
+        local cwd = vim.fn.getcwd()
+        local original_cwd = cwd
         if profiles.is_active_profile_set() then
-            local profile = profiles.get_active_profile()
-            local cwd = vim.fn.getcwd()
+            profile = profiles.get_active_profile()
             if cwd:sub(-1) ~= "/" then
                 cwd = cwd .. "/"
             end
 
-            local profile_path = profile.path
-            if profile_path:sub(1, 1) == "/" then
-                profile_path = profile_path:sub(2)
+            local binary_path = profile.binary_path
+            if binary_path:sub(1, 1) == "/" then
+                binary_path = binary_path:sub(2)
             end
 
-            config.program = cwd .. profile_path
+            local run_dir_path = profile.run_dir_path
+            if run_dir_path ~= nil and run_dir_path ~= "" then
+                if run_dir_path:sub(-1) ~= "/" then
+                    run_dir_path = run_dir_path .. "/"
+                end
+
+                if run_dir_path:sub(1, 1) == "/" then
+                    run_dir_path = run_dir_path:sub(2)
+                end
+
+                cwd = cwd .. run_dir_path
+            end
+
+            config.program = cwd .. binary_path
         end
 
+        event_dispatcher.fire_callbacks(events.PRE_DAP_RUN, profile, cwd)
         original_run(config, opts)
+        event_dispatcher.fire_callbacks(events.POST_DAP_RUN, profile, original_cwd)
+    end
+end
+
+local function profile_has_run_dir(profile)
+    return profile ~= nil and profile.run_dir_path ~= nil and profile.run_dir_path ~= ""
+end
+
+local function change_cwd_if_run_dir(profile, path)
+    if not profile_has_run_dir(profile) then
+        return
+    end
+
+    vim.api.nvim_set_current_dir(path)
+end
+
+local function change_cwd_to_run_dir(profile, cwd)
+    change_cwd_if_run_dir(profile, cwd)
+end
+
+local function change_cwd_to_original_dir(profile, original_cwd)
+    change_cwd_if_run_dir(profile, original_cwd)
+end
+
+local function setup_hooks()
+    profiles_run()
+
+    local callbacks = {
+        [events.PRE_DAP_RUN] = {
+            change_cwd_to_run_dir,
+        },
+        [events.POST_DAP_RUN] = {
+            change_cwd_to_original_dir,
+        },
+    }
+
+    for event, event_callbacks in pairs(callbacks) do
+        for _, callback in pairs(event_callbacks) do
+            event_dispatcher.add_callback(event, callback)
+        end
     end
 end
 
 function M.run()
+    for _, event in pairs(events) do
+        event_dispatcher.add_event(event)
+    end
+
     serializer.deserialize_profiles()
-    intercept_run_fn_and_insert_program()
+    setup_hooks()
 end
 
 return M

--- a/lua/nvim-dap-profiles/app.lua
+++ b/lua/nvim-dap-profiles/app.lua
@@ -45,9 +45,9 @@ local function profiles_run()
             config.program = cwd .. binary_path
         end
 
-        event_dispatcher.fire_callbacks(events.PRE_DAP_RUN, profile, cwd)
+        event_dispatcher.fire(events.PRE_DAP_RUN, profile, cwd)
         original_run(config, opts)
-        event_dispatcher.fire_callbacks(events.POST_DAP_RUN, profile, original_cwd)
+        event_dispatcher.fire(events.POST_DAP_RUN, profile, original_cwd)
     end
 end
 

--- a/lua/nvim-dap-profiles/app.lua
+++ b/lua/nvim-dap-profiles/app.lua
@@ -92,7 +92,7 @@ end
 
 function M.run()
     for _, event in pairs(events) do
-        event_dispatcher.add_event(event)
+        event_dispatcher.add_event_group(event)
     end
 
     serializer.deserialize_profiles()

--- a/lua/nvim-dap-profiles/app.lua
+++ b/lua/nvim-dap-profiles/app.lua
@@ -13,7 +13,7 @@ local function profiles_run()
         -- the latest profiles if the user updated the file directly.
         -- This should not be an issue as long as the profiles are serialized after any changes.
         -- Otherwise, we would risk running with outdated profiles.
-        serializer.deserialize_profiles()
+        serializer.deserialize_profiles(true)
 
         local profile = nil
         local cwd = vim.fn.getcwd()

--- a/lua/nvim-dap-profiles/event_dispatcher.lua
+++ b/lua/nvim-dap-profiles/event_dispatcher.lua
@@ -1,0 +1,56 @@
+local type = require("nvim-dap-profiles.type")
+
+local M = {}
+
+local all_callbacks = {}
+
+function M.clear_events()
+    all_callbacks = {}
+end
+
+function M.add_event_group(event)
+    assert(type.get(event) == "event", "Event must be an event type")
+    assert(all_callbacks[event] == nil, "Event group already exists")
+
+    all_callbacks[event] = {}
+end
+
+-- Use returned index to remove callback
+function M.add_callback(event, callback)
+    assert(event, "Event cannot be nil")
+    assert(callback, "Callback cannot be nil")
+    assert(type.get(event) == "event", "Event must be an event type")
+    assert(type.get(callback) == "function", "Callback must be a function")
+
+    table.insert(all_callbacks[event], callback)
+    return #all_callbacks[event]
+end
+
+-- We could create a system that tracks which indices are empty
+-- and reuse them when adding new callbacks, but that would be
+-- overkill for this use case
+function M.remove_callback(event, index)
+    assert(event, "Event cannot be nil")
+    assert(type.get(event) == "event", "Event must be an event type")
+    assert(type.get(index) == "number", "Index must be a number")
+    assert(all_callbacks[event][index], "Index is not valid, callback doesn't exist")
+
+    -- We have to make sure that the indices for the remaining
+    -- callbacks are not affected by the removal, so removing
+    -- should leave a hole in the table
+    all_callbacks[event][index] = nil
+end
+
+function M.fire_callbacks(event, ...)
+    assert(event, "Event cannot be nil")
+    assert(type.get(event) == "event", "Event must be an event type")
+
+    for _, callback in ipairs(all_callbacks[event]) do
+        -- Expected behavior to have nil callbacks if they were removed
+        if callback then
+            callback(...)
+        end
+    end
+end
+
+return M

--- a/lua/nvim-dap-profiles/event_dispatcher.lua
+++ b/lua/nvim-dap-profiles/event_dispatcher.lua
@@ -41,7 +41,7 @@ function M.remove_callback(event, index)
     all_callbacks[event][index] = nil
 end
 
-function M.fire_callbacks(event, ...)
+function M.fire(event, ...)
     assert(event, "Event cannot be nil")
     assert(type.get(event) == "event", "Event must be an event type")
 

--- a/lua/nvim-dap-profiles/events.lua
+++ b/lua/nvim-dap-profiles/events.lua
@@ -1,0 +1,12 @@
+local type = require("nvim-dap-profiles.type")
+
+local M = {
+    PRE_DAP_RUN = "PRE_DAP_RUN",
+    POST_DAP_RUN = "POST_DAP_RUN",
+}
+
+for _, event in pairs(M) do
+    type.create(event, "event")
+end
+
+return M

--- a/lua/nvim-dap-profiles/events.lua
+++ b/lua/nvim-dap-profiles/events.lua
@@ -6,7 +6,7 @@ local M = {
 }
 
 for _, event in pairs(M) do
-    type.create(event, "event")
+    M[event] = type.create(event, "event")
 end
 
 return M

--- a/lua/nvim-dap-profiles/profiles.lua
+++ b/lua/nvim-dap-profiles/profiles.lua
@@ -5,8 +5,12 @@ local M = {}
 --[[
 A profile contains the path to the binary and a name for the profile:
 {
-    name = "profile_name",
-    path = "/path/to/binary"
+    -- Given a path like this: ~/dev/git/proj_root/client/cmake-build-debug/binary_name
+    -- where the absolute root would be ~/dev/git/proj_root, then we would have a profile like this if we want to run the client binary:
+    -- OBS: It's not important to change the run_dir_path unless the binary have some resource dependencies. You can just change the binary_path as well.
+    name = "name of the profile, for instance 'client', 'server', or 'main' etc",
+    binary_path = "cmake-build-debug/binary_name" -- This is relative from the root of the project + run_dir_path
+    run_dir_path = "client" -- This is relative from the root of the project
 }
 --]]
 local all_profiles = {}
@@ -21,7 +25,7 @@ function M.is_profile_valid(profile_name)
     end
 
     local profile = M.get_profile(profile_name)
-    return valid_check(profile.name) and valid_check(profile.path)
+    return valid_check(profile.name) and valid_check(profile.binary_path)
 end
 
 function M.profile_exists(profile_name)
@@ -32,13 +36,13 @@ end
 function M.set_active_profile(profile_name)
     assert(profile_name ~= nil and profile_name ~= "", "Profile name is nil or empty")
     assert(M.profile_exists(profile_name), "Profile does not exist: " .. profile_name)
-    assert(M.is_profile_valid(profile_name), "Profile is not valid: " .. profile_name)
+    assert(M.is_profile_valid(profile_name), "Given profile is not valid: " .. profile_name)
     assert(active_profile ~= profile_name, "Active profile already set: " .. profile_name)
 
     active_profile = profile_name
 
     assert(M.get_active_profile() == M.get_profile(active_profile), "Active profile was not set correctly")
-    assert(M.is_profile_valid(active_profile), "Profile is not valid: " .. active_profile)
+    assert(M.is_profile_valid(active_profile), "Active profile is not valid: " .. active_profile)
 end
 
 function M.is_active_profile_set()
@@ -54,22 +58,23 @@ function M.get_profile(profile_name)
     return all_profiles[profile_name]
 end
 
-function M.create_profiles(names, paths, profile_to_activate)
+function M.create_profiles(names, binary_paths, run_dir_paths, profile_to_activate)
     assert(names ~= nil and #names > 0, "Names is nil or empty")
-    assert(paths ~= nil and #paths > 0, "Paths is nil or empty")
-    assert(#paths == #names, "Paths and names are not the same length")
+    assert(binary_paths ~= nil and #binary_paths > 0, "Paths is nil or empty")
+    assert(#binary_paths == #names, "Paths and names are not the same length")
 
-    for i, path in ipairs(paths) do
+    for i = 1, #names do
         assert(names[i] ~= nil and names[i] ~= "", "Name is nil or empty")
-        assert(path ~= nil and path ~= "", "Path is nil or empty")
+        assert(binary_paths[i] ~= nil and binary_paths[i] ~= "", "Path is nil or empty")
 
-        M.create_profile(names[i], path, names[i] == profile_to_activate)
+        local run_dir = run_dir_paths and run_dir_paths[i] or nil
+        M.create_profile(names[i], binary_paths[i], run_dir, names[i] == profile_to_activate)
     end
 end
 
-function M.create_profile(name, path, activate)
+function M.create_profile(name, binary_path, run_dir_path, activate)
     assert(name ~= nil and name ~= "", "Name is nil or empty")
-    assert(path ~= nil and path ~= "", "Path is nil or empty")
+    assert(binary_path ~= nil and binary_path ~= "", "Path is nil or empty")
     assert(not M.profile_exists(name), "Profile already exists: " .. name)
 
     local prev_tot_profiles = tbl.len(all_profiles)
@@ -77,9 +82,11 @@ function M.create_profile(name, path, activate)
         activate = true
     end
 
+    run_dir_path = run_dir_path or ""
     all_profiles[name] = {
         name = name,
-        path = path
+        binary_path = binary_path,
+        run_dir_path = run_dir_path,
     }
 
     if activate then
@@ -124,8 +131,6 @@ end
 function M.delete_all_profiles()
     all_profiles = {}
     active_profile = nil
-
-    -- TODO: Update the Toml file
 end
 
 function M.get_num_profiles()

--- a/lua/nvim-dap-profiles/profiles_serializer.lua
+++ b/lua/nvim-dap-profiles/profiles_serializer.lua
@@ -32,7 +32,7 @@ function M.serialize_profiles(profiles_file_override)
     toml.encode_to_file(get_file_name(profiles_file_override), table_to_serialize)
 end
 
-function M.deserialize_profiles(profiles_file_override)
+function M.deserialize_profiles(delete_previous_profiles, profiles_file_override)
     if not profiles_file_exists(profiles_file_override) then
         return
     end
@@ -72,6 +72,11 @@ function M.deserialize_profiles(profiles_file_override)
     local profile_to_activate = nil
     if data.active_profile ~= nil then
         profile_to_activate = data.active_profile
+    end
+
+    delete_previous_profiles = delete_previous_profiles or false
+    if delete_previous_profiles then
+        profiles.delete_all_profiles()
     end
 
     profiles.create_profiles(names, binary_paths, run_dir_paths, profile_to_activate)

--- a/lua/nvim-dap-profiles/profiles_serializer.lua
+++ b/lua/nvim-dap-profiles/profiles_serializer.lua
@@ -5,8 +5,13 @@ local M = {}
 
 local profiles_file_name = ".nvim-dap-profiles.toml"
 
-local function profiles_file_exists()
-    local file = io.open(profiles_file_name, "r")
+-- This function is mainly intended to streamline testing
+local function get_file_name(profiles_file_override)
+    return profiles_file_override or profiles_file_name
+end
+
+local function profiles_file_exists(profiles_file_override)
+    local file = io.open(get_file_name(profiles_file_override), "r")
     if file == nil then
         return false
     end
@@ -15,7 +20,7 @@ local function profiles_file_exists()
     return true
 end
 
-function M.serialize_profiles()
+function M.serialize_profiles(profiles_file_override)
     local table_to_serialize = {
         all_profiles = profiles.get_all_profiles(),
     }
@@ -24,15 +29,15 @@ function M.serialize_profiles()
         table_to_serialize.active_profile = profiles.get_active_profile().name
     end
 
-    toml.encode_to_file(profiles_file_name, table_to_serialize)
+    toml.encode_to_file(get_file_name(profiles_file_override), table_to_serialize)
 end
 
-function M.deserialize_profiles()
-    if not profiles_file_exists() then
+function M.deserialize_profiles(profiles_file_override)
+    if not profiles_file_exists(profiles_file_override) then
         return
     end
 
-    local data = toml.decode_from_file(profiles_file_name)
+    local data = toml.decode_from_file(get_file_name(profiles_file_override))
     if not data then
         return
     end
@@ -42,17 +47,25 @@ function M.deserialize_profiles()
     end
 
     local names = {}
-    local paths = {}
+    local binary_paths = {}
+    local run_dir_paths = {}
     for _, profile in pairs(data.all_profiles) do
         local valid_name = profile.name and profile.name ~= ""
-        local valid_path = profile.path and profile.path ~= ""
+        local valid_path = profile.binary_path and profile.binary_path ~= ""
         if valid_name and valid_path then
             table.insert(names, profile.name)
-            table.insert(paths, profile.path)
+            table.insert(binary_paths, profile.binary_path)
+
+            local valid_run_dir = profile.run_dir_path and profile.run_dir_path ~= ""
+            if valid_run_dir then
+                table.insert(run_dir_paths, profile.run_dir_path)
+            else
+                table.insert(run_dir_paths, nil)
+            end
         end
     end
 
-    if #names == 0 or #paths == 0 then
+    if #names == 0 or #binary_paths == 0 then
         return
     end
 
@@ -61,7 +74,7 @@ function M.deserialize_profiles()
         profile_to_activate = data.active_profile
     end
 
-    profiles.create_profiles(names, paths, profile_to_activate)
+    profiles.create_profiles(names, binary_paths, run_dir_paths, profile_to_activate)
 end
 
 return M

--- a/lua/nvim-dap-profiles/type.lua
+++ b/lua/nvim-dap-profiles/type.lua
@@ -1,0 +1,54 @@
+local M = {}
+
+function M.create(obj, custom_type)
+    assert(obj ~= nil, "obj cannot be nil")
+    assert(type(custom_type) == "string", "custom_type must be a string")
+    assert(custom_type ~= "", "custom_type cannot be empty")
+
+    local value = obj
+    if type(obj) ~= "table" then
+        obj = {}
+    end
+
+    setmetatable(obj, {
+        __value = value,
+        __type = custom_type,
+        __index = function(self, _)
+            return rawget(getmetatable(self), "__value")
+        end,
+        __newindex = function(self, _, new_value)
+            getmetatable(self).__value = new_value
+        end,
+        __tostring = function(self)
+            return tostring(rawget(getmetatable(self), "__value"))
+        end,
+        __concat = function(self, other)
+            return tostring(self) .. tostring(other)
+        end,
+        __eq = function(self, other)
+            local a = rawget(getmetatable(self), "__value")
+            local b = other
+
+            local other_mt = getmetatable(other)
+            if type(other) == "table" and other_mt and rawget(other_mt, "__type") then
+                b = rawget(other_mt, "__value")
+            end
+
+            return a == b
+        end,
+    })
+
+    return obj
+end
+
+-- nil is a valid type, so we need to check for it
+function M.get(obj)
+    local mt = getmetatable(obj)
+    if mt and mt.__type then
+        return mt.__type
+    else
+        return type(obj)
+    end
+end
+
+return M

--- a/tests/event_dispatcher_spec.lua
+++ b/tests/event_dispatcher_spec.lua
@@ -1,58 +1,24 @@
 package.path = package.path .. ";lua/?.lua"
 
 describe("Event Dispatcher", function()
-    -- local events = require("nvim-dap-profiles.events")
-    -- local event_dispatcher = require("nvim-dap-profiles.event_dispatcher")
-    --
-    -- it("Adds event group", function()
-    --     local event = events.PRE_DAP_RUN
-    --     event_dispatcher.add_event_group(event)
-    --     assert.is_not_nil(event_dispatcher.get_callbacks(event))
-    -- end)
-    --
-    -- it("Fires callbacks for event", function()
-    --     local event = events.PRE_DAP_RUN
-    --
-    --     local callback1_called = false
-    --     local function callback1()
-    --         callback1_called = true
-    --     end
-    --
-    --     local callback2_called = false
-    --     local function callback2()
-    --         callback2_called = true
-    --     end
-    --
-    --     event_dispatcher.add_callback(event, callback1)
-    --     event_dispatcher.add_callback(event, callback2)
-    --
-    --     event_dispatcher.fire_callbacks(event)
-    --
-    --     assert.is_true(callback1_called)
-    --     assert.is_true(callback2_called)
-    -- end)
-    --
-    -- it("Removes callback", function()
-    --     local event = events.PRE_DAP_RUN
-    --
-    --     local callback1_called = false
-    --     local function callback1()
-    --         callback1_called = true
-    --     end
-    --
-    --     local callback2_called = false
-    --     local function callback2()
-    --         callback2_called = true
-    --     end
-    --
-    --     event_dispatcher.add_callback(event, callback1)
-    --     local callback2_index = event_dispatcher.add_callback(event, callback2)
-    --
-    --     event_dispatcher.remove_callback(event, callback2_index)
-    --
-    --     event_dispatcher.fire_callbacks(event)
-    --
-    --     assert.is_true(callback1_called)
-    --     assert.is_false(callback2_called)
-    -- end)
+    local events = require("nvim-dap-profiles.events")
+    local event_dispatcher = require("nvim-dap-profiles.event_dispatcher")
+
+    it("Adds event group", function()
+        event_dispatcher.add_event_group(events.PRE_DAP_RUN)
+
+        local did_callback_run = false
+        local callback_id = event_dispatcher.add_callback(events.PRE_DAP_RUN, function()
+            did_callback_run = true
+        end)
+
+        assert.is_false(did_callback_run)
+        event_dispatcher.fire(events.PRE_DAP_RUN)
+        assert.is_true(did_callback_run)
+
+        did_callback_run = false
+        event_dispatcher.remove_callback(events.PRE_DAP_RUN, callback_id)
+        event_dispatcher.fire(events.PRE_DAP_RUN)
+        assert.is_false(did_callback_run)
+    end)
 end)

--- a/tests/event_dispatcher_spec.lua
+++ b/tests/event_dispatcher_spec.lua
@@ -1,0 +1,58 @@
+package.path = package.path .. ";lua/?.lua"
+
+describe("Event Dispatcher", function()
+    -- local events = require("nvim-dap-profiles.events")
+    -- local event_dispatcher = require("nvim-dap-profiles.event_dispatcher")
+    --
+    -- it("Adds event group", function()
+    --     local event = events.PRE_DAP_RUN
+    --     event_dispatcher.add_event_group(event)
+    --     assert.is_not_nil(event_dispatcher.get_callbacks(event))
+    -- end)
+    --
+    -- it("Fires callbacks for event", function()
+    --     local event = events.PRE_DAP_RUN
+    --
+    --     local callback1_called = false
+    --     local function callback1()
+    --         callback1_called = true
+    --     end
+    --
+    --     local callback2_called = false
+    --     local function callback2()
+    --         callback2_called = true
+    --     end
+    --
+    --     event_dispatcher.add_callback(event, callback1)
+    --     event_dispatcher.add_callback(event, callback2)
+    --
+    --     event_dispatcher.fire_callbacks(event)
+    --
+    --     assert.is_true(callback1_called)
+    --     assert.is_true(callback2_called)
+    -- end)
+    --
+    -- it("Removes callback", function()
+    --     local event = events.PRE_DAP_RUN
+    --
+    --     local callback1_called = false
+    --     local function callback1()
+    --         callback1_called = true
+    --     end
+    --
+    --     local callback2_called = false
+    --     local function callback2()
+    --         callback2_called = true
+    --     end
+    --
+    --     event_dispatcher.add_callback(event, callback1)
+    --     local callback2_index = event_dispatcher.add_callback(event, callback2)
+    --
+    --     event_dispatcher.remove_callback(event, callback2_index)
+    --
+    --     event_dispatcher.fire_callbacks(event)
+    --
+    --     assert.is_true(callback1_called)
+    --     assert.is_false(callback2_called)
+    -- end)
+end)

--- a/tests/profiles_serializer_spec.lua
+++ b/tests/profiles_serializer_spec.lua
@@ -30,8 +30,7 @@ describe("Profiles Serializer", function()
         local profiles_from_code = clone(profiles.get_all_profiles())
         serializer.serialize_profiles(path_to_test_file)
 
-        profiles.delete_all_profiles()
-        serializer.deserialize_profiles(path_to_test_file)
+        serializer.deserialize_profiles(true, path_to_test_file)
         local profiles_from_file = profiles.get_all_profiles()
 
         assert.truthy(profiles_from_code)

--- a/tests/profiles_serializer_spec.lua
+++ b/tests/profiles_serializer_spec.lua
@@ -18,26 +18,22 @@ describe("Profiles Serializer", function()
 
     local serializer = require("nvim-dap-profiles.profiles_serializer")
     local profiles = require("nvim-dap-profiles.profiles")
+    local path_to_test_file = "tests/toml_profiles.toml"
 
     local names = { "test1", "test2", "test3" }
-    local paths = { "path1", "path2", "path3" }
+    local binary_paths = { "path1", "path2", "path3" }
+    local run_dir_paths = { "", nil, "run_dir3" }
     it("De/Serialize", function()
         profiles.delete_all_profiles()
 
-        profiles.create_profiles(names, paths, "test2")
+        profiles.create_profiles(names, binary_paths, run_dir_paths, "test2")
         local profiles_from_code = clone(profiles.get_all_profiles())
-        serializer.serialize_profiles()
+        serializer.serialize_profiles(path_to_test_file)
 
         profiles.delete_all_profiles()
-        local data = serializer.deserialize_profiles()
-        local all_profiles = profiles.get_all_profiles()
-        local active_profile = profiles.get_active_profile()
-        local compare = {
-            active_profile = active_profile,
-            all_profiles = all_profiles,
-        }
-
+        serializer.deserialize_profiles(path_to_test_file)
         local profiles_from_file = profiles.get_all_profiles()
+
         assert.truthy(profiles_from_code)
         assert.truthy(profiles_from_file)
         assert.same(profiles_from_code, profiles_from_file)

--- a/tests/profiles_serializer_spec.lua
+++ b/tests/profiles_serializer_spec.lua
@@ -4,7 +4,7 @@ describe("Profiles Serializer", function()
     local function clone(source)
         local orig_type = type(source)
         local copy
-        if orig_type == 'table' then
+        if orig_type == "table" then
             copy = {}
             for orig_key, orig_value in next, source, nil do
                 copy[clone(orig_key)] = clone(orig_value)

--- a/tests/profiles_spec.lua
+++ b/tests/profiles_spec.lua
@@ -10,12 +10,20 @@ describe("Profiles", function()
         local profile = profiles.get_profile(name)
         local active_profile = profiles.get_active_profile()
         profiles.create_profile(name .. "2", path .. "2")
+        local run_dir = "test_run_dir"
+        profiles.create_profile(name .. "3", path .. "3", run_dir)
 
+        local profile3 = profiles.get_profile(name .. "3")
         assert.truthy(profile ~= nil)
         assert.truthy(active_profile ~= nil)
         assert.same(profile.name, name)
         assert.same(profile, active_profile)
         assert.is_not.same(profile, profiles.get_profile(name .. "2"))
+
+        assert.truthy(profile3 ~= nil)
+        assert.same(profile3.name, name .. "3")
+        assert.is_not.same(profile3, profiles.get_profile(name .. "2"))
+        assert.truthy(profile3.run_dir_path == run_dir)
 
         profiles.delete_all_profiles()
     end)
@@ -23,7 +31,7 @@ describe("Profiles", function()
         local names = { "profile1", "profile2", "profile3" }
         local paths = { "path/to/binary", "path/to/binary2", "path/to/binary3" }
         local active_profile_name = names[2]
-        profiles.create_profiles(names, paths, active_profile_name)
+        profiles.create_profiles(names, paths, nil, active_profile_name)
 
         for i, _ in ipairs(paths) do
             assert.truthy(profiles.is_profile_valid(names[i]))

--- a/tests/profiles_spec.lua
+++ b/tests/profiles_spec.lua
@@ -3,6 +3,9 @@ package.path = package.path .. ";lua/?.lua"
 describe("Profiles", function()
     local profiles = require("nvim-dap-profiles.profiles")
 
+    before_each(function()
+        profiles.delete_all_profiles()
+    end)
     it("Create a new profile", function()
         local name = "profile"
         local path = "path/to/binary"
@@ -24,8 +27,6 @@ describe("Profiles", function()
         assert.same(profile3.name, name .. "3")
         assert.is_not.same(profile3, profiles.get_profile(name .. "2"))
         assert.truthy(profile3.run_dir_path == run_dir)
-
-        profiles.delete_all_profiles()
     end)
     it("Create a batch of profiles and activate one", function()
         local names = { "profile1", "profile2", "profile3" }
@@ -38,8 +39,6 @@ describe("Profiles", function()
         end
 
         assert.truthy(profiles.get_active_profile().name == active_profile_name)
-
-        profiles.delete_all_profiles()
     end)
     it("Switch between profiles", function()
         local names = { "profile1", "profile2", "profile3" }
@@ -56,8 +55,6 @@ describe("Profiles", function()
         end
 
         assert.truthy(profiles.get_active_profile().name == names[1])
-
-        profiles.delete_all_profiles()
     end)
     it("Get the active profile", function()
         local name = "profile1"
@@ -66,8 +63,6 @@ describe("Profiles", function()
         assert.truthy(active ~= nil)
         assert.truthy(active.name == name)
         assert.truthy(profiles.is_profile_valid(name))
-
-        profiles.delete_all_profiles()
     end)
     it("Getters return the same value", function()
         local name = "profile1"
@@ -75,8 +70,6 @@ describe("Profiles", function()
         local profile = profiles.get_profile(name)
         local active = profiles.get_active_profile()
         assert.same(profile, active)
-
-        profiles.delete_all_profiles()
     end)
     it("Profile exists behaves as expected", function()
         local profiles_to_create = {
@@ -108,8 +101,6 @@ describe("Profiles", function()
         for _, name in ipairs(invalid_profile_names) do
             assert.falsy(profiles.profile_exists(name))
         end
-
-        profiles.delete_all_profiles()
     end)
     it("Delete profiles", function()
         local profiles_to_create = {

--- a/tests/toml_spec.lua
+++ b/tests/toml_spec.lua
@@ -26,15 +26,16 @@ describe("Toml", function()
             all_profiles = {
                 profile1 = {
                     name = "profile1",
-                    path = "path/to/binary1"
+                    binary_path = "path/to/binary1"
                 },
                 profile2 = {
                     name = "profile2",
-                    path = "path/to/binary2"
+                    binary_path = "path/to/binary2",
+                    run_dir_path = "path/to/run_dir"
                 },
                 profile3 = {
                     name = "profile3",
-                    path = "path/to/binary3"
+                    binary_path = "path/to/binary3"
                 },
             }
         }

--- a/tests/type_spec.lua
+++ b/tests/type_spec.lua
@@ -1,0 +1,53 @@
+package.path = package.path .. ";lua/?.lua"
+
+describe("Type", function()
+    local type = require("nvim-dap-profiles.type")
+    it("Type accuracy", function()
+        local custom_types = {
+            { {},    "event" },
+            { {},    "test" },
+            { "lol", "test2" },
+            { 123,   "test3" },
+        }
+
+        local all_types = {
+            { function() end, "function" },
+            { "string",       "string" },
+            { 123,            "number" },
+            { true,           "boolean" },
+            { {},             "table" },
+            { nil,            "nil" },
+        }
+
+        for _, custom_type in pairs(custom_types) do
+            local is_value_type = type.get(custom_type[1]) ~= "table"
+            local value_copy = custom_type[1]
+
+            custom_type[1] = type.create(unpack(custom_type))
+            table.insert(all_types, custom_type)
+
+            if is_value_type then
+                assert.equals(tostring(value_copy), tostring(custom_type[1]))
+            end
+        end
+
+        for _, test_type in pairs(all_types) do
+            local a = type.get(test_type[1])
+            local b = test_type[2]
+            assert.equals(a, b)
+        end
+    end)
+    it("Value changes", function()
+        local custom1 = type.create("test", "event")
+        assert.equals(tostring(custom1), "test")
+
+        custom1 = "testvalue"
+        assert.equals(tostring(custom1), "testvalue")
+
+        local custom2 = type.create(123, "event")
+        assert.equals(tostring(custom2), "123")
+
+        custom2 = 456
+        assert.equals(tostring(custom2), "456")
+    end)
+end)


### PR DESCRIPTION
Add a feature which lets you temporarily change directory before you run the binary if you want to. This solves an issue where in some projects the output of the binary has some resource dependencies and it expects you to run the binary from a certain directory.